### PR TITLE
Cabal2 fix

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -10,7 +10,7 @@ import Control.Applicative ((<$>))
 -- Cabal
 import Distribution.Simple
 import Distribution.PackageDescription
-import Distribution.PackageDescription.Parse (readPackageDescription)
+import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
 import Distribution.Verbosity (normal)
 -- Version
 import Data.Version
@@ -30,7 +30,7 @@ data Aux = Aux { guideVersion :: Version }
 
 getAux :: IO Aux
 getAux = do
-  pd <- packageDescription <$> readPackageDescription normal "hatex-guide.cabal"
+  pd <- packageDescription <$> readGenericPackageDescription normal "hatex-guide.cabal"
   return $ Aux (pkgVersion $ package pd)
 
 auxmodule :: Aux -> String

--- a/Setup.hs
+++ b/Setup.hs
@@ -12,8 +12,6 @@ import Distribution.Simple
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
 import Distribution.Verbosity (normal)
--- Version
-import Data.Version
 
 main :: IO ()
 main = do
@@ -45,5 +43,5 @@ auxmodule a = unlines [
  , "-- | The version of the guide. Based on the version of the package."
  , "guideVersion :: Version"
  , "guideVersion = " ++ (let v = guideVersion a
-                         in  "Version " ++ show (versionBranch v) ++ " []")
+                         in  "makeVersion " ++ show (versionNumbers v))
    ]


### PR DESCRIPTION
This fixes #21 by simply not using the Version datatype from Data.Version in Setup.hs. It also uses a different function for reading Package descriptions, since the old one is no longer available in Cabal 2.

This fix is dependent on the previous one I made for issue #22. I'm new to git, so please correct me if I made a mistake here.