### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 _Welcome to the HaTeX User's Guide!_
 
 A pdf version (created from the LaTeX output) can be downloaded from
-[here](http://daniel-diaz.github.com/projects/hatex/hatex-guide.pdf).
+[here](http://daniel-diaz.github.io/projects/hatex/hatex-guide.pdf).
 
 An online version (created from the HTML output) can be seen
-[here](http://daniel-diaz.github.com/projects/hatex/hatex-guide.html).
+[here](http://daniel-diaz.github.io/projects/hatex/hatex-guide.html).
 
 # Building the guide
 


### PR DESCRIPTION
Github retired subdomains of github.com, instead we should use github.io
subdomains.